### PR TITLE
Add a hook to allow extraction of extra data from SDP to suit business case.

### DIFF
--- a/respoke/call.js
+++ b/respoke/call.js
@@ -266,15 +266,6 @@ module.exports = function (params) {
     });
 
     /**
-     * extracted extra info from the sdp
-     * may be basis for call rejection/auto answer
-     *
-     * @name remoteSdpExtract
-     * @type {string}
-     */
-    that.remoteSdpExtract = undefined;
-    
-    /**
      * Array of streams of remote media that we are receiving from the remote party.
      * @name incomingMediaStreams
      * @type {Array<respoke.RemoteMedia>}
@@ -598,6 +589,20 @@ module.exports = function (params) {
 
         localMedia.start();
     }
+    /**
+     *
+     * optionally inspect or manipulate the remoteSDP before 
+     * it is applied
+     * @memberof! respoke.Call
+     * @method respoke.Call.remoteSDP
+     * @param {SessionDescription} remoteSession
+     * @public
+     * @returns SessionDescription
+     */
+    that.remoteSDP = function(remoteSession){
+	return remoteSession;
+    };
+
 
     /**
      * Answer the call and start the process of obtaining media. This method is called automatically on the caller's
@@ -1434,6 +1439,7 @@ module.exports = function (params) {
         var info = {};
 
         that.sessionId = evt.signal.sessionId;
+        evt.signal.sessionDescription = that.remoteSDP(evt.signal.sessionDescription);
         pc.state.receiveOnly = respoke.sdpHasSendOnly(evt.signal.sessionDescription.sdp);
         pc.state.sendOnly = respoke.sdpHasReceiveOnly(evt.signal.sessionDescription.sdp);
         pc.state.listen('connecting:entry', function () {
@@ -1453,10 +1459,6 @@ module.exports = function (params) {
          * TODO not good enough for media renegotiation
          */
 
-        /*
-         * extra info for accept/reject choice
-         */
-        that.remoteSdpExtract = respoke.sdpExtract(evt.signal.sessionDescription.sdp);
         // If sendOnly, we can't rely on the offer for media estimate. It doesn't have any media in it!
         if (pc.state.sendOnly) {
             updateOutgoingMediaEstimate({constraints: {

--- a/respoke/peerConnection.js
+++ b/respoke/peerConnection.js
@@ -837,6 +837,7 @@ module.exports = function (params) {
             return;
         }
         log.debug('got answer', evt.signal);
+	evt.signal.sessionDescription = that.call.remoteSDP(evt.signal.sessionDescription);
 
         that.report.sdpsReceived.push(evt.signal.sessionDescription);
         that.state.sendOnly = respoke.sdpHasReceiveOnly(evt.signal.sessionDescription.sdp);

--- a/respoke/respoke.js
+++ b/respoke/respoke.js
@@ -514,17 +514,6 @@ respoke.isEqual = function (a, b) {
     return a === b;
 };
 
-/*  
- * extract something from the sdp
- * set this method to glean extra info on an sdp param
- * @static 
- * @memberof respoke
- * @params {RTCSessionDescription}
- * @returns {boolean}
- */
-respoke.sdpExtract = function(sdp){
-    return undefined;
-}
 /*
  * Does the sdp indicate an audio stream?
  * @static


### PR DESCRIPTION
The idea here is to allow the respoke developer (user?) to extract some extra data from the incoming SDP that may impact their business case. (for example if the fingerprint matches one this user 'trusts').
Respoke can't be expected to expose all possible SDP data, but the expert user may want to get at some specific info (e.g. dtmf support, or license paid codecs)  before accepting the call.
Notice that the SDP isn't expected to be edited, so core functionality isn't changed.

This PR is used like this :
client = new respoke.Client({
                                appId: appid,
                                developmentMode: true
                            });
                            respoke.log.setLevel('trace');
                            respoke.sdpExtract = Ipseorama.getFinger;
....
client.listen('call', function(evt) {
           call = evt.call;
           if ((call.initiator !== true) && (call.remoteSdpExtract == oldFriend)){
            call.answer(
...
         } else {
           call.reject(
... etc
