### PR TITLE
Add basic hooks for group history

### DIFF
--- a/respoke/group.js
+++ b/respoke/group.js
@@ -383,6 +383,7 @@ module.exports = function (params) {
      * @param {string} params.message - The message.
      * @param {boolean} [params.push=false] - Whether or not the message should be considered for push notifications to
      * mobile devices.
+     * @param {boolean} [params.persist=false] - Whether or not the message should be persisted in history.
      * @param {function} params.onSuccess - Success handler indicating that the message was delivered.
      * @param {function} params.onError - Error handler indicating that the message was not delivered.
      * @returns {Promise|undefined}

--- a/respoke/group.js
+++ b/respoke/group.js
@@ -164,6 +164,54 @@ module.exports = function (params) {
     };
 
     /**
+     * Retrieve the persisted message history for this group.
+     *
+     *     group.getHistory({
+     *         onSuccess: function (history) {
+     *             // A list of persisted messages
+     *         },
+     *         onError: function (err) {
+     *             // Something bad happened
+     *         }
+     *     });
+     *
+     * @memberof! respoke.Group
+     * @method respoke.Group.getHistory
+     * @param {object} params
+     * @param {respoke.Client.joinHandler} [params.onSuccess] - Success handler for this invocation of
+     * this method only.
+     * @param {respoke.Client.errorHandler} [params.onError] - Error handler for this invocation of this
+     * method only.
+     * @param {number} [params.limit] The number of messages to retrieve. Default is 50.
+     * @param {number} [params.before] Epoch timestamp determining where to start retrieving history.
+     * @return {Promise|undefined}
+     * @fires respoke.Client#leave
+     */
+    that.getHistory = function (params) {
+        params = params || {};
+        params.group = that.id;
+
+        var deferred = Q.defer();
+        var retVal = respoke.handlePromise(deferred.promise, params.onSuccess, params.onError);
+
+        try {
+            validateConnection();
+            validateMembership();
+        } catch (err) {
+            deferred.reject(err);
+            return retVal;
+        }
+
+        signalingChannel.getGroupHistory(params)
+        .done(function successHandler(history) {
+            deferred.resolve(history);
+        }, function errorHandler(err) {
+            deferred.reject(err);
+        });
+        return retVal;
+    };
+
+    /**
      * Leave this group. If this method is called multiple times synchronously, it will batch requests and
      * only make one API call to Respoke.
      *

--- a/respoke/signalingChannel.js
+++ b/respoke/signalingChannel.js
@@ -806,6 +806,42 @@ module.exports = function (params) {
     })();
 
     /**
+     * Retrieve persisted message history for a specific group
+     * @memberof! respoke.SignalingChannel
+     * @private
+     * @method respoke.SignalingChannel.getGroupHistory
+     * @returns {Promise}
+     * @param {object} params
+     * @param {string} params.group The group whose history we should retrieve
+     * @param {number} [params.limit] The number of messages to retrieve. Default is 50.
+     * @param {number} [params.before] Epoch timestamp determining where to start retrieving history.
+     */
+    that.getGroupHistory = function (params) {
+        var deferred = Q.defer();
+
+        if (!that.isConnected()) {
+            deferred.reject(new Error("Can't complete request when not connected. Please reconnect!"));
+            return deferred.promise;
+        }
+
+        wsCall({
+            httpMethod: 'GET',
+            path: '/v1/groups/{group}/history',
+            urlParams: { group: params.group },
+            parameters: {
+                limit: params.limit || 50,
+                before: params.before
+            }
+        }).done(function successHandler(history) {
+            deferred.resolve(history);
+        }, function errorHandler(err) {
+            deferred.reject(err);
+        });
+
+        return deferred.promise;
+    };
+
+    /**
      * Publish a message to a group.
      * @memberof! respoke.SignalingChannel
      * @private

--- a/respoke/signalingChannel.js
+++ b/respoke/signalingChannel.js
@@ -815,6 +815,7 @@ module.exports = function (params) {
      * @param {string} params.id
      * @param {string} params.message
      * @param {boolean} [params.push=false]
+     * @param {boolean} [params.persist=false]
      */
     that.publish = function (params) {
         params = params || {};
@@ -822,7 +823,8 @@ module.exports = function (params) {
         var message = respoke.TextMessage({
             endpointId: params.id,
             message: params.message,
-            push: !!params.push
+            push: !!params.push,
+            persist: !!params.persist
         });
 
         if (!that.isConnected()) {

--- a/respoke/signalingChannel.js
+++ b/respoke/signalingChannel.js
@@ -832,11 +832,7 @@ module.exports = function (params) {
                 limit: params.limit || 50,
                 before: params.before
             }
-        }).done(function successHandler(history) {
-            deferred.resolve(history);
-        }, function errorHandler(err) {
-            deferred.reject(err);
-        });
+        }).done(deferred.resolve, deferred.reject);
 
         return deferred.promise;
     };

--- a/spec/unit/group.spec.js
+++ b/spec/unit/group.spec.js
@@ -42,6 +42,7 @@ describe("A respoke.Group", function () {
                     expect(typeof group.sendMessage).to.equal('function');
                     expect(typeof group.getMembers).to.equal('function');
                     expect(typeof group.isJoined).to.equal('function');
+                    expect(typeof group.getHistory).to.equal('function');
                 });
 
                 it("saves unexpected developer-specified parameters.", function () {
@@ -81,6 +82,35 @@ describe("A respoke.Group", function () {
                                 message: "There's no place like home",
                                 onSuccess: function () {
                                     done(new Error("sendMessage() succeeded when not connected."));
+                                },
+                                onError: function (err) {
+                                    expect(err).to.exist;
+                                    expect(err.message).to.contain("not connected");
+                                    done();
+                                }
+                            });
+                        });
+                    });
+                });
+
+                describe("getHistory()", function () {
+                    describe("promise-style", function () {
+                        it("errors because of lack of connection", function (done) {
+                            group.getHistory().done(function () {
+                                done(new Error("getHistory() succeeded when not connected."));
+                            }, function (err) {
+                                expect(err).to.exist;
+                                expect(err.message).to.contain("not connected");
+                                done();
+                            });
+                        });
+                    });
+
+                    describe("callback-style", function () {
+                        it("errors because of lack of connection", function (done) {
+                            group.getHistory({
+                                onSuccess: function () {
+                                    done(new Error("getHistory() succeeded when not connected."));
                                 },
                                 onError: function (err) {
                                     expect(err).to.exist;

--- a/spec/util/mockSignalingChannel.js
+++ b/spec/util/mockSignalingChannel.js
@@ -54,6 +54,13 @@ window.MockSignalingChannel = function MockSignalingChannel(signalChannelParams)
         return deferred.promise;
     };
 
+    that.getGroupHistory = function (params) {
+        params = params || {};
+        var deferred = Q.defer();
+        deferred.resolve([]);
+        return deferred.promise();
+    };
+
     that.leaveGroup = function (params) {
         var deferred = Q.defer();
         deferred.resolve();


### PR DESCRIPTION
This patch add some very basic support for persisting messages published to a group, and for later retrieving those messages. This is equivalent to passing the `persist` flag when publishing to a group (or channel, as this library still uses the old route), and hitting the `GET /v1/groups/:group/history` route to pull the history.

![image](https://user-images.githubusercontent.com/2288718/28494833-c102855a-6eff-11e7-9ce7-7ac676d4bed2.png)
